### PR TITLE
escape spaces in linux directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For Mac:
 
 For Linux:
 
-`~/.steam/steam/SteamApps/common/Team\ Fortress\ 2/tf/cfg`
+`~/.steam/steam/steamapps/common/Team\ Fortress\ 2/tf/cfg`
  
 After you do that, just start up your game and type 'setup' in console, and you'll be good to go.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For Mac:
 
 For Linux:
 
-`~/.steam/steam/SteamApps/common/Team Fortress 2/tf/cfg`
+`~/.steam/steam/SteamApps/common/Team\ Fortress\ 2/tf/cfg`
  
 After you do that, just start up your game and type 'setup' in console, and you'll be good to go.
 


### PR DESCRIPTION
similar to #19, and has the same reason. 