### PR TITLE
Figured I'd look through your config and send a pull request since you seem open to constructive criticism.

### DIFF
--- a/tf/cfg/autoexec.cfg
+++ b/tf/cfg/autoexec.cfg
@@ -98,8 +98,6 @@ rate 60000 // anything above 62,000 is completely useless, anything above 48,000
 //cl_updaterate 40
 //rate 35000
 
-net_queue_trace 1 // Seems to optimize net code, not sure
-
 //----------------------------------------------------------------------------
 // Sprays
 // No/negligible performance benefit. Only useful to disable if you're annoyed by them.
@@ -113,7 +111,6 @@ r_spray_lifetime 2      // Set to 0 to disable.
 // Shadows can provide a tactical advantage, but at the same time can lower FPS, especially in busy areas.
 //----------------------------------------------------------------------------
 
-//mat_shadowstate 0					// Set to 1 to enable.
 //r_shadowmaxrendered 0				// Set to 11 to enable.
 //r_shadowrendertotexture 0			// Set to 1 to enable, but can cause lag; 0 is the recommended setting either way.
 //r_shadows 0						// Set to 1 to enable.
@@ -128,11 +125,8 @@ r_spray_lifetime 2      // Set to 0 to disable.
 //r_flex 0 			// Set to 1 to enable.
 //r_lod 2 			// Needs to be set to 1, or else facial features will be disabled regardless.
 //r_teeth 0 			// Set to 1 to enable.
-//mp_usehwmmodels -1  // disables improved facial expressions (problems with multicore, for some reason), added for completeness even though the cvar is technically non-functioning since 3/15/14
-//mp_usehwmvcds -1 	// disables improved facial expressions, added for completeness even though the cvar is technically non-functioning since 3/15/14
 
 // Extra settings for if you want to enable facial features but still have a performance benefit. Only uncomment if you have facial features turned on.
-//r_eyegloss 0
 //r_eyemove 0
 //r_eyeshift_x 0
 //r_eyeshift_y 0
@@ -177,6 +171,7 @@ cl_burninggibs 0                // Disables burning gibs. Enough of a performanc
 //snd_pitchquality 1						// Helps determine what to set the audio quality at. More info a few lines down.						
 //snd_spatialize_roundrobin 1				// Lowend optimization: if nonzero, spatialize only a fraction of sound channels each frame. 1/2^x of channels will be spatialized
 //snd_mixahead 0.05						// Sets how long it takes until attack sounds play. By default the setting is 0.1, or 100ms, which is 1/10 of a second. That means that the current value plays it 50ms after attacking. Sounds usually start to glitch at lower values, so play around with this and see how low you can get!
+snd_mix_async 1							// Should result in a performance boost on multicore cpus.
 
 // dsp_slow_cpu and snd_pitchquality determine what your audio quality is set to in the Options menu.
 // High: snd_pitchquality 1; dsp_slow_cpu 0
@@ -191,13 +186,10 @@ cl_burninggibs 0                // Disables burning gibs. Enough of a performanc
 //----------------------------------------------------------------------------
 
 cl_hud_playerclass_use_playermodel 0 // Potential FPS gain, we'll see after more thorough testing
-mat_phong 0							// Disables phonging on all models. Also achieved by enabling DX8. Disables lightwarps. Can make some models appear black.
-cl_detaildist 0 					// Distance at which the detailed parts of props are no longer visible (lower LODs)
-cl_detailfade 0						// Distance across which detail props fade in
-cl_drawmonitors 0					// Disables the rendering of in-game "monitors" which contain 3D rendered images. Mostly unused except maybe in some DR maps
-cl_muzzleflash_dlight_1st 0         //
+mat_phong 0							// Disables phong shading on all models. Also achieved by enabling DX8. Disables lightwarps. Can make some models appear black.
+cl_drawmonitors 0					// Disables the rendering of in-game "monitors" which render things in front of a camera somewhere else on the map (think Dr. Breen in HL2 train station). Mostly unused except maybe in some DR maps
 cl_jiggle_bone_framerate_cutoff 0 	// Turns off jigglebones, although I recommend keeping them on at all times by setting them to 1, since their performance impact is generally none/negligible.
-cl_new_impact_effects 0				// Disables new impact effects
+cl_new_impact_effects 0				// Disables new impact effects. Even if you have a high end computer, this will cause crashes as of ~Apr 2015.
 cl_show_splashes 0					// Disables water splashes
 func_break_max_pieces 0				// Undocumented, but probably the same as props_break_max_pieces
 glow_outline_effect_enable 0 		// Cart glow effect. Performance loss with this is generally negligible, however, so I recommend enabling it simply because of how useful it is.
@@ -206,54 +198,37 @@ mat_antialias 1						// Sets lowest antialiasing value.
 mat_bumpmap 0 						// Controls bumpmapping. Apparently it has a weird shine effect if used on dx9, but I'm not seeing it. Set to 1 if you experience it.
 mat_colcorrection_disableentities 0 // Disables color-correcting entities.
 mat_colorcorrection 0				// Disables color-correction.
-mat_disable_bloom 1					// Disables the bloom effect that allows light to reflect off of a surface, and the HDR effect.
 mat_disable_fancy_blending 1		// Disables fancy texture blending.
 mat_disable_lightwarp 1				// Disables lightwarps, which partially determine shading for players, entities, and the map. mat_phong also does this.
-mat_envmapsize 8					// Changes envmap size.
-mat_envmaptgasize 8					// Messes around with size of sprayed textures
 mat_disable_ps_patch 1              //
-mat_filterlightmaps 1				// Filters lightmaps.
-mat_filtertextures 1				// Filters textures.
+mat_filterlightmaps 1				// Filters lightmaps. Set to 0 for minecraft lighting. No performance impact.
+mat_filtertextures 1				// Filters textures. Set to 0 for minecraft textures. No performance impact.
 mat_forceaniso 1					// Forces anisotropic filtering level
 mat_hdr_level 0						// Sets HDR level.
 mat_max_worldmesh_vertices 65535		// Determines how many chunks world geometry is broken up into. Higher = less, 65535 is the theoretical maximum
 mat_monitorgamma 2.0 				// Controls brightness, try 1.8 to make it brighter or 2.2 to get it darker. Only works in fullscreen.
 mat_motion_blur_enabled 0			// Disables motion blur.
-mat_parallaxmap 0					// Disables parallax mapping.
-mat_mipmaptextures 1				// Control mipmapping
-mat_reducefillrate 1				// Reduces the fillrate when the game is run in DX8.
+mat_mipmaptextures 1				// Controls mipmapping. Setting this to 0 should not improve performance, and will not affect vram usage like mat_picmip will.
+mat_reducefillrate 1				// Reduces shader complexity.
 mat_reduceparticles 1				// Reduces particle count.
-mat_softwarelighting 0              // Disables rendering of lights by the software.
 mat_autoexposure_max 0              //
 mat_autoexposure_min 0              //
-mat_alphacoverage 0                 //
-mat_diffuse 1                       //
-mat_non_hdr_bloom_scalefactor 0     //
-mat_bloomscale 0                    // More assurance that bloom stays off
-mat_bloom_scalefactor_scalar 0      //
+mat_alphacoverage 0                 // Reduces shader complexity for some transparent materials.
 mat_specular 1 						// Controls specularity. Setting this to 0 will make ubers non-shiny, and will remove some specular effects from in-game entities which support it.
-mat_fastspecular 1					// Fast specularity.
-mat_fastnobump 0                    //
 mat_forcemanagedtextureintohardware 0
-mat_framebuffercopyoverlaysize 0    //
 mat_trilinear 0 					// Sets trlinear mode.
-mat_viewportscale 1 				// Almost no performance gain from viewport upscaling.
-mat_viewportupscale 1				//
+mat_viewportscale 1 				// Allows lowering viewport resolution without affecting game resolution. Recommended to just lower your game resolution though.
 mat_wateroverlaysize 1				// Water overlay size.
 mp_decals 9 						// `9' is a good value to still see the spread pattern from a scattergun without any real performance loss. Needs to be changed with r_decals.
 r_3dsky 0							// Disables 3D skies. This makes maps like koth_wubwubwub much, much less spectacular, so you need to compromise.
-//r_3dnow 0							// Disables 3DNow, but it doesn't take arguments in TF2
 r_ambientboost 0					// Controls ambient lights
-r_ambientfactor 0					// Controls ambient lights
-r_ambientmin 0						// Controls ambient lights
-r_avglight 0						// Controls average lighting on objects
 r_cheapwaterend 1					// Activates cheap water
 r_cheapwaterstart 1					// Activates cheap water
 r_decals 9							// Controls decal amount. Needs to be changed with mp_decals.
 r_maxmodeldecal 9                   // Controls how many decals can be on a model at once
 r_decalstaticprops 0				// Enables whether decals can be seen on props.
 r_decal_cullsize 15					// Controls the cull size of decals.
-r_drawdetailprops 0					// Controls whether details on props should be drawn at all.
+r_drawdetailprops 0					// Controls whether detail props (grass, etc.) should be drawn.
 r_drawmodeldecals 0					// Controls whether decals should be seeable on a model.
 r_drawflecks 0						// Controls whether particles upon hitting a surface with a bullet should be rendered.
 r_dynamic 0							// Disables dynamic lighting.
@@ -261,15 +236,11 @@ r_maxdlights 0						// Determines the maximum number of dynamic lights visible o
 r_physpropstaticlighting 0			// Dtermines if there should be static lighting on props
 r_occlusion	1						// Allows mappers to manually optimize their map. Theoretical FPS loss with it DISABLED, which is why it's enabled.
 r_worldlights 1                     // Number of world lights to use per vertex. Set to 0 for a theoretical performance gain but very bad lighting effects on characters.
-r_flashlightdepthtexture 0			// Specifies how detailed the flashlight light should be. Useless in TF2. 
 r_forcewaterleaf 1					// Optimization to water - considers view in leaf under water for purposes of culling.
 r_lightaverage 0					// Disables average lighting.
 r_dopixelvisibility 0               //
-r_maxnewsamples 0					// Undocumented.
-r_maxsampledist 1					// Undocumented.
-r_sse2 1                            //
-r_propsmaxdist 0					// Max visible distance for props.
-r_renderoverlayfragment 0			// Leaves a marking underneath health kits and ammo kits.
+r_propsmaxdist 0					// Max visible distance for clientside physics props.
+r_renderoverlayfragment 0			// Disables various mapmaker-placed signs and decals, like those underneath health and ammo packs.
 r_staticprop_lod 10					// Sets the default LOD for static props. Undocumented, so I don't know the limit, but 10 is a good number.
 r_waterdrawreflection 0				// Controls as to whether reflections should be drawn on the surface of water.
 r_waterdrawrefraction 1				// Setting to 0 makes it so that water looks weird and you can't look into it, but it might have an FPS gain.
@@ -283,7 +254,7 @@ rope_smooth 0						// Controls as to whether there should be an antialiasing eff
 rope_subdiv 0						// Rope subdivision amount.
 rope_wind_dist 0					// If a rope is this far away, don't simulate wind on them.
 tf_particles_disable_weather 1 		// Disable weather effects on maps supporting it. For example, setting this to `1' disables rain effects on *_sawmill.
-tracer_extra 0						// Undocumented.
+tracer_extra 0						// Enlarges tracers at long distance to make them more visible.
 violence_ablood 1 					// Setting ablood/hblood to 1 actually improves perf usually
 violence_hblood 1					//
 
@@ -330,10 +301,8 @@ mat_queue_mode 2 // mat_queue mode is another frequently asked about cvar, it
 
 cl_threaded_client_leaf_system 0
 r_queued_ropes 1
-r_queued_post_processing 0
 r_threaded_client_shadow_manager 1
 r_threaded_particles 1
-r_threaded_renderables 1
 cl_forcepreload 1								   // Forces preloading sounds and such to make it lag less when in-game.
 //mat_viewportupscale 1                            // for terrible GPU's only
 //mat_viewportscale 0.5                            // for terrible GPU's only
@@ -347,7 +316,6 @@ cl_software_cursor 0       						   // fixes Windows cursor appearing on screen 
 //cl_ejectbrass 0			   	// Disables visual bullet ejection from miniguns. Causes crashes for some clients.
 //cl_localnetworkbackdoor 0          // Network optimizations for Singleplayer, disabling has about a 1-2% fps boost
 //cl_cloud_settings 0                // Disables cloud syncing of configs, should decrease FPS variance. Disable if you want to.
-//sys_minidumpspewlines 500            // Basically the number of lines saved to a log file from console. No FPS boost but 15% lower FPS variance. Proven useless.
 cl_loadondemand_default 0          // Forces items to be loaded at startup instead of on demand. Theoretically makes startup longer but prevents freezing
 //ai_expression_optimization 1       // Disables NPC expressions when you can't see them, not sure if it works on regular players in TF2, but that's why it's experimental.
 //r_pixelfog 0                     // Apparently changes fog clarity to give a more DX8-ish appearance when set to 1.
@@ -359,11 +327,7 @@ cl_loadondemand_default 0          // Forces items to be loaded at startup inste
 //mod_load_mesh_async 1              // Load model mesh async
 //mod_load_vcollide_async 1          // Load model vcollide async
 r_queued_post_processing 1
-r_threaded_client_shadow_manager 1
-r_threaded_particles 1
 r_threaded_renderables 1
-net_queue_trace 0
-cl_cloud_settings 0 				// Disables Steam Cloud syncing for TF2, helps to keep the config from being saved so you don't contaminate Steam Cloud with it
 
 // cl_loadondemand_default stays at 0 regardless as to whether you choose to use experimental features or not simply because it provides
 // a straight up benefit and isn't unstable.


### PR DESCRIPTION
///////////
// Added //
///////////

* snd_mix_async 1
    Performance boost on multithreaded cpus. Added.

/////////////
// Removed //
/////////////

* net_queue_trace 1
    Enables debug messages for the queued packet thread (net_queued_packet_thread 1). Code  seems to have been removed since 2007.

* mat_shadowstate 1
    Isn't hooked up to anything as of 2007, and from multiple tests across different Source games, I don't believe this does anything anymore.

* mp_usehwmmodels/vcds
    You state yourself these do nothing, and I agree.

* r_eyegloss
    Not hooked up as of 2007, and no visible changes ingame.

* cl_detaildist 0
* cl_detailfade 0
    You already set r_drawdetailprops 0, which completely disables the detail prop system. Setting cl_detaildist 0 and cl_detailfade 0 just prevents detail props individually from being drawn because they are too far away. Basically, r_drawdetailprops 0 makes these cvars entirely redundant and improves performance compared to r_drawdetailprops 1 + cl_detaildist 0 + cl_detailfade 0.

* cl_muzzleflash_dlight_1st 0
We're not playing Day of Defeat: Source, so this cvar does nothing.

* mat_envmapsize 8
* mat_envmaptgasize 8
Has no effect on performance unless you are running the "lightprobe" or
"envmap" commands in the console.

* mat_disable_bloom 1
* mat_bloomscale 0
* mat_non_hdr_bloom_scalefactor 0
* mat_bloom_scalefactor_scalar 0
Redundant if mat_hdr_level is set to 0.

* mat_parallaxmap 0
There are no shaders in Source that utilize parallax mapping.

* mat_softwarelighting 0
This already defaults off, and enabling it will significantly reduce
performance.

* mat_diffuse 1
Already defaults to 1, and is a cheat.

* mat_fastspecular 1
* mat_fastnobump 0
These cvars are designed to let you instantly compare the effects of
specularity/bump mapping on and off without waiting for material reloads
caused by mat_specular and mat_bumpmap. They are made redundant by
turning off mat_specular and mat_bumpmap, do not affect performance, and
do not reduce vram usage.

* mat_framebuffercopyoverlaysize 0
Controls the size of the framebuffer copy texture if it is being
displayed by mat_showframebuffertexture. Does not affect performance in
any way, and only does something if you have sv_cheats 1 +
mat_showframebuffertexture 1.

* mat_viewportupscale 1
Default is already 1, and you'd be insane to try playing with this off
and mat_viewportscale < 1. Trust me.

* r_3dnow 0
Can't test whether this really doesn't take arguments in TF2 because I
own an Intel CPU, but the presence of SSE already overrides the usage of
the older, slower 3DNow extensions.

* r_ambientfactor 0
* r_ambientmin 0
Redundant if r_ambientboost is set to 0. Additionally, the lower these
values are set, the higher the chance that ambient light boosting will
occur. Either way, these cvars are for visual tweaking, and the effect
they have on performance is immeasurably small.

* r_avglight 0
Cheat cvar.

* r_flashlightdepthtexture 0
Like you say, useless in TF2.

* r_maxnewsamples 0
* r_maxsampledist 1
Not hooked up as of 2007, and likely never will be.

* r_sse2 1
The engine will automatically enable this if your cpu supports it, and
disabling sse2 instructions will only result in performance loss.

* sys_minidumpspewlines 500
Useless, like you say.

//////////////////////
// Food for thought //
//////////////////////

* r_threaded_renderables 1
Causes crashes for me.

* r_queued_post_processing 1
Causes crashes and/or missing postprocessing textures (pink and black
covering my whole screen). Fun!

* cl_ejectbrass 0
There is absolutly no reason I can see that this would cause crashes.

* tracer_extra 0
* r_propsmaxdist 0
Updated description.

* nb_shadow_dist 400
Didn't exist in 2007, but from its prefix "nb" it seems to be related to
NextBots (the bots used in tf2). Physics in Source also use something
called a "physics shadow" which leads me to believe it is related to
their pathing rather than visible shadows.

* mat_filterlightmaps 1
* mat_filtertextures 1
These will have no performance impact unless you have an incredibly old
graphics card... and I mean so old that tf2 wouldn't even run on it.

* mat_viewportscale 1
Rendering the viewport at a lower resolution then upscaling can result
in a significant performance boost if you are gpu-limited. However, the
performance boost will still be less significant than if you just
lowered your overall game resolution.